### PR TITLE
cleanup update_document in refreshdocstate

### DIFF
--- a/snotes20/management/commands/refreshdocstate.py
+++ b/snotes20/management/commands/refreshdocstate.py
@@ -1,9 +1,8 @@
 import logging
 import datetime
 import time
-import timeit
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.db import transaction
 
 import snotes20.models as models
@@ -17,33 +16,46 @@ def update_document(doc, sigh):
     prepped = contenttypes.prep_state(doc)
 
     with transaction.atomic():
-        try:
-            doc.state.delete()
-            doc.raw_state.delete()
-        except:
-            pass
-
         raw_state, state = contenttypes.get_state(prepped)
-
-        doc.raw_state = raw_state
-        doc.state = state
 
         raw_state.save()
         state.save()
-        doc.save()
+
+        _delete_old_states(doc)
+        _save_new_state_to_doc(doc, raw_state, state)
 
         if sigh:
-            raw_state, state = contenttypes.get_state(prepped)
-
             pub = models.Publication()
-            pub.raw_state = raw_state
-            pub.state = state
-            pub.creator = models.NUser.objects.get(pk=1)
-            pub.preliminary = True
-            pub.create_date = datetime.datetime(2000, 1, 1)
-            pub.episode = doc.episode
-            pub.save()
+            _save_state_to_publication(pub, doc.episode, raw_state, state)
 
+def _delete_old_states(doc):
+    if doc.state:
+        try:
+            if doc.state.publication:
+                doc.state.clear()
+        except models.Publication.DoesNotExist:
+            doc.state.delete()
+
+    if doc.raw_state:
+        try:
+            if doc.raw_state.publication_raw:
+                doc.raw_state.clear()
+        except models.Publication.DoesNotExist:
+            doc.raw_state.delete()
+
+def _save_new_state_to_doc(doc, raw_state, state):
+    doc.raw_state = raw_state
+    doc.state = state
+    doc.save()
+
+def _save_state_to_publication(pub, episode, raw_state, state):
+    pub.raw_state = raw_state
+    pub.state = state
+    pub.creator = models.NUser.objects.get(pk=1)
+    pub.preliminary = True
+    pub.create_date = datetime.datetime(2000, 1, 1)
+    pub.episode = episode
+    pub.save()
 
 def update_documents(docs, sigh):
     start_time = datetime.datetime.now()


### PR DESCRIPTION
don't generate states twice
don't delete states which also have a publication
better exception handling when deleting old states

@Drake81 
